### PR TITLE
fix: improve wget healthcheck with proper error handling

### DIFF
--- a/docker-compose.n8n.yml
+++ b/docker-compose.n8n.yml
@@ -22,7 +22,7 @@ services:
     networks:
       - n8n-network
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5678/healthz"]
+      test: ["CMD", "sh", "-c", "wget --quiet --spider --tries=1 --timeout=10 http://localhost:5678/healthz || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
- Add explicit shell wrapper for proper error handling
- Use --quiet instead of --no-verbose for consistency
- Add --timeout=10 to match Docker healthcheck timeout
- Add || exit 1 to ensure proper failure on HTTP errors
- This ensures the healthcheck fails correctly on 4xx/5xx responses

🤖 Generated with [Claude Code](https://claude.ai/code)